### PR TITLE
import imageio -> import imageio.v2 as imageio

### DIFF
--- a/crafter/engine.py
+++ b/crafter/engine.py
@@ -2,7 +2,7 @@ import collections
 import functools
 import pathlib
 
-import imageio
+import imageio.v2 as imageio
 import numpy as np
 from PIL import Image, ImageEnhance
 


### PR DESCRIPTION
DeprecationWarning: Starting with ImageIO v3 the behavior of this function will switch to that of iio.v3.imread. To keep the current behavior (and make this warning disappear) use `import imageio.v2 as imageio` or call `imageio.v2.imread` directly.